### PR TITLE
Fix async issue in example usage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,18 @@ var t = tree(feed)
 
 t.append('/hello.txt', 'hello')
 t.append('/world.txt', 'world')
-t.append('/foo/bar.txt', 'baz')
+t.append('/foo/bar.txt', 'baz', function () {
+  t.list('/', function (err, list) {
+    console.log(list) // prints ['hello.txt', 'world.txt']
+  })
 
-t.list('/', function (err, list) {
-  console.log(list) // prints ['hello.txt', 'world.txt']
-})
+  t.list('/foo', function (err, list) {
+    console.log(list) // prints ['bar.txt']
+  })
 
-t.list('/foo', function (err, list) {
-  console.log(list) // prints ['bar.txt']
-})
-
-t.get('/hello.txt', function (err, node) {
-  console.log(node.value.toString()) // prints hello
+  t.get('/hello.txt', function (err, node) {
+    console.log(node.value.toString()) // prints hello
+  })
 })
 ```
 


### PR DESCRIPTION
The calls to `t.list` etc must wait until the last `t.append` call have finished